### PR TITLE
Add line on how to create account

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,7 @@ How to use it?
 #. Boot the Pi from the SD card
 #. Hostname is ``librephotosos`` (not ``raspberrypi`` as usual), username: ``ubuntu`` and inital password is: ``ubuntu``
 #. After a few mintues you should be able to access ``http://librephotosos.local/`` or ``http://librephotosos.lan/``
+#. Create your librephotos account by finishing up the first time setup via the web interface
 #. You can change the settings of the docker settings are located at ``/boot/docker-compose/librephotos/``
 
 


### PR DESCRIPTION
A couple of users could not log in, because they tried the linux username and password instead. This should make it more clear on how to create an account for LibrePhotos.